### PR TITLE
Migrate from Gemini 1.5 to 2.0

### DIFF
--- a/src/language.ts
+++ b/src/language.ts
@@ -83,17 +83,17 @@ abstract class LatinScriptLanguage implements Language {
   initialPhrases: string[] = [];
   aiConfigs = {
     classic: {
-      model: 'gemini-1.5-flash-001',
+      model: 'gemini-2.0-flash-001',
       sentence: 'SentenceGeneric20250311',
       word: 'WordGeneric20240628',
     },
     fast: {
-      model: 'gemini-1.5-flash-002',
+      model: 'gemini-2.0-flash-lite-001',
       sentence: 'SentenceGeneric20250311',
       word: 'WordGeneric20240628',
     },
     smart: {
-      model: 'gemini-1.5-pro-002',
+      model: 'gemini-2.0-pro-exp',
       sentence: 'SentenceGeneric20250311',
       word: 'WordGeneric20240628',
     },


### PR DESCRIPTION
Migration plan:
- classic: 1.5-flash-001 -> 2.0-flash-001
- fast: 1.5-flash-002 -> 2.0-flash-lite-001
- smart: 1.5-pro-002 -> 2.0-pro-exp

Offline manual testing results look fine: they are usually faster, and the results are not worse

References:
- https://ai.google.dev/gemini-api/docs/models
