### PR TITLE
Add AudioManager for audio buffering

### DIFF
--- a/src/audio-manager.ts
+++ b/src/audio-manager.ts
@@ -1,0 +1,79 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare global {
+  interface Window {
+    webkitAudioContext: typeof AudioContext;
+  }
+}
+
+let clickBuffer: AudioBuffer | null = null;
+let chimeBuffer: AudioBuffer | null = null;
+const ctx = new (window.AudioContext || window.webkitAudioContext)();
+
+fetch('/static/click2.wav')
+  .then(response => response.arrayBuffer())
+  .then(arrayBuffer => ctx.decodeAudioData(arrayBuffer))
+  .then(audioBuffer => {
+    clickBuffer = audioBuffer;
+  })
+  .catch(error => {
+    console.warn('Error loading click audio file:', error);
+  });
+
+fetch('/static/chime.wav')
+  .then(response => response.arrayBuffer())
+  .then(arrayBuffer => ctx.decodeAudioData(arrayBuffer))
+  .then(audioBuffer => {
+    chimeBuffer = audioBuffer;
+  })
+  .catch(error => {
+    console.warn('Error loading chime audio file:', error);
+  });
+
+export class AudioManager {
+  static playClick(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      if (!clickBuffer) {
+        return reject('Click audio buffer is not loaded yet.');
+      }
+      const source = ctx.createBufferSource();
+      source.buffer = clickBuffer;
+      source.connect(ctx.destination);
+      source.onended = () => {
+        source.disconnect();
+        resolve();
+      };
+      source.start(ctx.currentTime);
+    });
+  }
+
+  static playChime(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      if (!chimeBuffer) {
+        return reject('Chime audio buffer is not loaded yet.');
+      }
+      const source = ctx.createBufferSource();
+      source.buffer = chimeBuffer;
+      source.connect(ctx.destination);
+      source.onended = () => {
+        source.disconnect();
+        resolve();
+      };
+      source.start(ctx.currentTime);
+    });
+  }
+}

--- a/src/pv-app.ts
+++ b/src/pv-app.ts
@@ -28,6 +28,7 @@ import {SignalWatcher} from '@lit-labs/signals';
 import {html, LitElement} from 'lit';
 import {customElement, property, query} from 'lit/decorators.js';
 
+import {AudioManager} from './audio-manager.js';
 import {LARGE_MARGIN_LINE_LIMIT} from './constants.js';
 import {InputSource} from './input-history.js';
 import {LANGUAGES} from './language.js';
@@ -105,10 +106,7 @@ function playClickSound() {
   ) {
     const originalMethod = descriptor.value;
     descriptor.value = function (this: PvAppElement, ...args: unknown[]) {
-      if (this.state.enableEarcons) {
-        const audio = new Audio('/static/click2.wav');
-        audio.play();
-      }
+      if (this.state.enableEarcons) AudioManager.playClick();
       return originalMethod.apply(this, args);
     };
     return descriptor;

--- a/src/pv-functions-bar.ts
+++ b/src/pv-functions-bar.ts
@@ -24,6 +24,7 @@ import {SignalWatcher} from '@lit-labs/signals';
 import {css, html, LitElement} from 'lit';
 import {customElement, property} from 'lit/decorators.js';
 
+import {AudioManager} from './audio-manager.js';
 import {State} from './state.js';
 
 const EVENT_KEY = {
@@ -268,11 +269,7 @@ export class PvFunctionsBar extends SignalWatcher(LitElement) {
     tts.cancel();
 
     if (this.state.enableEarcons) {
-      const audio = new Audio('/static/chime.wav');
-      audio.addEventListener('canplaythrough', () => {
-        audio.play();
-      });
-      audio.addEventListener('ended', () => {
+      AudioManager.playChime().then(() => {
         this.startTts();
       });
     } else {


### PR DESCRIPTION
Instantiating an Audio object takes time to load the audio source over the network or even from the browser cache.
By loading the audio source beforehand and reusing it, we can play those sounds responsively to user actions.