### PR TITLE
Remove 2.5 model and set classic to 1.5 pro

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -19,7 +19,7 @@ import {Config} from './config-storage.js';
 export const RUN_MACRO_ENDPOINT_URL = '/run-macro';
 
 export const CONFIG_DEFAULT: Config = {
-  aiConfig: 'classic',
+  aiConfig: 'smart',
   enableEarcons: false,
   expandAtOrigin: false,
   initialPhrases: [],

--- a/src/language.ts
+++ b/src/language.ts
@@ -80,7 +80,7 @@ abstract class LatinScriptLanguage implements Language {
   initialPhrases: string[] = [];
   aiConfigs = {
     classic: {
-      model: 'gemini-2.0-flash-001',
+      model: 'gemini-1.5-pro-002',
       sentence: 'SentenceGeneric20250311',
       word: 'WordGeneric20240628',
     },
@@ -90,7 +90,7 @@ abstract class LatinScriptLanguage implements Language {
       word: 'WordGeneric20240628',
     },
     smart: {
-      model: 'gemini-2.5-pro-exp-03-25',
+      model: 'gemini-2.0-flash-001',
       sentence: 'SentenceGeneric20250311',
       word: 'WordGeneric20240628',
     },
@@ -159,7 +159,7 @@ abstract class Japanese implements Language {
   ];
   aiConfigs = {
     classic: {
-      model: 'gemini-2.0-flash-001',
+      model: 'gemini-1.5-pro-002',
       sentence: 'SentenceJapanese20240628',
       word: 'WordGeneric20240628',
     },
@@ -169,7 +169,7 @@ abstract class Japanese implements Language {
       word: 'WordGeneric20240628',
     },
     smart: {
-      model: 'gemini-2.5-pro-exp-03-25',
+      model: 'gemini-2.0-flash-001',
       sentence: 'SentenceJapaneseLong20241002',
       word: 'WordGeneric20240628',
     },

--- a/src/state.ts
+++ b/src/state.ts
@@ -64,7 +64,7 @@ class State {
     this.textSignal.set(newText);
   }
 
-  private aiConfigInternal = 'classic';
+  private aiConfigInternal = 'smart';
 
   get aiConfig() {
     return this.aiConfigInternal;


### PR DESCRIPTION
Due to rate limit of Gemini 2.5 pro model, we do not tend to use it for now.