### PR TITLE
fix: install uv in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,22 +10,23 @@ WORKDIR /app
 
 # Install necessary packages, also install some network utilities for debugging purpose
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends python3 python-is-python3 \
+    apt-get install -y --no-install-recommends python3 \
     python3-venv python3-pip net-tools iproute2 iputils-ping curl
 
 # Copy all files into container
 COPY . /app
 
-# Install uv for Python dependency management
-RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh
+# Setup python virtual environment
+RUN python3 -m venv /venv
+ENV PATH="/venv/bin:$PATH"
 
-# Allow pip to install packages system-wide (bypasses PEP 668 externally managed environment error)
-ENV PIP_BREAK_SYSTEM_PACKAGES=1
+# Install uv for Python dependency management
+RUN pip install uv
 
 # Install Node.js dependencies and run build script
 RUN npm install && npm run build
 
 EXPOSE 5000
 
-ENTRYPOINT ["uv", "run", "python"]
+ENTRYPOINT ["python"]
 CMD ["main.py"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,6 +19,9 @@ COPY . /app
 # Install uv for Python dependency management
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh
 
+# Allow pip to install packages system-wide (bypasses PEP 668 externally managed environment error)
+ENV PIP_BREAK_SYSTEM_PACKAGES=1
+
 # Install Node.js dependencies and run build script
 RUN npm install && npm run build
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,23 +10,19 @@ WORKDIR /app
 
 # Install necessary packages, also install some network utilities for debugging purpose
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends python3 \
+    apt-get install -y --no-install-recommends python3 python-is-python3 \
     python3-venv python3-pip net-tools iproute2 iputils-ping curl
 
 # Copy all files into container
 COPY . /app
 
-# Setup python virtual environment
-RUN python3 -m venv /venv
-ENV PATH="/venv/bin:$PATH"
-
 # Install uv for Python dependency management
-RUN pip install uv
+RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh
 
 # Install Node.js dependencies and run build script
 RUN npm install && npm run build
 
 EXPOSE 5000
 
-ENTRYPOINT ["python"]
+ENTRYPOINT ["uv", "run", "python"]
 CMD ["main.py"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,6 +20,9 @@ COPY . /app
 RUN python3 -m venv /venv
 ENV PATH="/venv/bin:$PATH"
 
+# Install uv for Python dependency management
+RUN pip install uv
+
 # Install Node.js dependencies and run build script
 RUN npm install && npm run build
 


### PR DESCRIPTION
This change installs `uv` in `docker/Dockerfile` before running `npm install`. This is necessary because `npm install` runs the `postinstall` script, which now executes `uv sync`. Since `uv` was missing from the Docker image, the build failed with exit code 127.

The base image `node:lts-slim` provides `node` and `npm`, and we now install `uv` into the Python virtual environment using `pip install uv`.

---
*PR created automatically by Jules for task [2150961431041193940](https://jules.google.com/task/2150961431041193940) started by @tushuhei*